### PR TITLE
[design-tracker] props 사용횟수를 정확히 추출합니다.

### DIFF
--- a/.changeset/silver-snakes-beam.md
+++ b/.changeset/silver-snakes-beam.md
@@ -1,0 +1,5 @@
+---
+"@ndive/design-tracker": patch
+---
+
+[design-tracker] props 사용횟수를 정확히 추출합니다.

--- a/packages/design-tracker/src/utils/loadConfig.ts
+++ b/packages/design-tracker/src/utils/loadConfig.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import path from 'node:path'
 
 import {cosmiconfig, CosmiconfigResult} from 'cosmiconfig'
@@ -53,7 +52,7 @@ export const loadConfig = async (
                   isEmpty: boolean
               }
             | undefined
-    } catch (error) {
-        console.error('something went wrong while loading config file.', error)
+    } catch {
+        /** IGNORE */
     }
 }


### PR DESCRIPTION
- 저번 코드가 잘못된 점 : Typescript 정적 분석으로 모든 props를 가져온거지 실제 sorucefile에서 가져온게 아님
- 실제로 소스 코드에서 사용된 횟수만큼 추출하기 위해 코드를 수정합니다.
- 또한 JSXElement가 아닌 일반 상수도 export하고 있으므로 이들의 type도 importType으로 가져옵니다.
